### PR TITLE
Add new `split_lines` filter

### DIFF
--- a/django/template/defaultfilters.py
+++ b/django/template/defaultfilters.py
@@ -432,6 +432,20 @@ def cut(value, arg):
     return value
 
 
+@register.filter
+@stringfilter
+def split_lines(value):
+    """
+    Return a list of strings split on the newline ("\n" or "\r\n") character
+    Removes any blank lines
+    """
+    if '\r' in value:
+        return [val for val in value.split('\r\n') if val != '']
+    else:
+        return [val for val in value.split('\n') if val != '']
+
+
+
 ###################
 # HTML STRINGS    #
 ###################


### PR DESCRIPTION
A new `split_lines` filter has been added allowing text strings to be split within templates. This gives developers easy access to basic python string manipulation. Since some operating systems put "\r" by default, this function handles this scenario.